### PR TITLE
Use system compiler linux

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -9,8 +9,8 @@ if [ $(uname) == "Darwin" ]; then
     export DYLIB="dylib"
     LINKER_FLAGS="-L${PREFIX}/lib"
 else
-    CC=${PREFIX}/bin/gcc
-    CXX=${PREFIX}/bin/g++
+    CC=gcc
+    CXX=g++
     export DYLIB="so"
     LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
 fi
@@ -30,7 +30,8 @@ cmake .. \
     -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB} \
     -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
     -DPYTHON_INCLUDE_DIR2=${PREFIX}/include/python${PY_ABI} \
-    -DWITH_LOG=OFF
+    -DWITH_LOG=OFF \
+    -D_GLIBCXX_USE_CXX11_ABI=0
 
 make -j${CPU_COUNT}
 make install

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -4,7 +4,7 @@ cd build
 if [ $(uname) == "Darwin" ]; then
     CC=clang
     CXX=clang++
-    CXXFLAGS="-std=c++11 -stdlib=libc++"
+    CXXFLAGS="-std=c++11 -stdlib=libc++ ${CXXFLAGS}"
     
     export DYLIB="dylib"
     LINKER_FLAGS="-L${PREFIX}/lib"
@@ -13,6 +13,7 @@ else
     CXX=g++
     export DYLIB="so"
     LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
+    CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
 fi
 
 PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")
@@ -31,7 +32,6 @@ cmake .. \
     -DPYTHON_INCLUDE_DIR=${PREFIX}/include/python${PY_ABI} \
     -DPYTHON_INCLUDE_DIR2=${PREFIX}/include/python${PY_ABI} \
     -DWITH_LOG=OFF \
-    -D_GLIBCXX_USE_CXX11_ABI=0
 
 make -j${CPU_COUNT}
 make install

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -13,7 +13,10 @@ else
     CXX=g++
     export DYLIB="so"
     LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
-    CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    # enable compilation without CXX abi to stay compatible with gcc < 5 built packages
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    fi
 fi
 
 PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,6 @@ build:
 
 requirements:
   build:
-    - gcc 4.8.5 # [linux]
     - patchelf # [linux]
     - boost 1.55.0 # [py2k]
     - boost 1.63.0.* # [py3k]
@@ -31,7 +30,6 @@ requirements:
     - python {{PY_VER}}*
 
   run:
-    - libgcc 4.8.5 # [linux]
     - patchelf # [linux]
     - boost 1.55.0 # [py2k]
     - boost 1.63.0.* # [py3k]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     path: ../
 
 build:
-  number: 0
+  number: 1
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
   detect_binary_files_with_prefix: true
   msvc_compiler: 14.0  # [win]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,9 @@ build:
   msvc_compiler: 14.0  # [win]
   features:
     - vc14 # [win]
+  script_env:
+    # Control building with CXX11 abi
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:
   build:


### PR DESCRIPTION
This is related to allowing dependencies to be built with newer gcc than the one available through conda (4.8.5 atm), in particular, recent nifty changes forced us to use a newer compiler.

See some more background on this in https://github.com/ilastik/ilastik-publish-packages/issues/2

In order to use the system compilers this PR removes

* references to gcc, libgcc in the respective meta.yaml files
* points to the correct compiler in build.sh
* introduces an environment variable DO_NOT_BUILD_WITH_CXX11_ABI that is used in the build process to enable building with -D_GLIBCXX_USE_CXX11_ABI=0 to enable compatibility with the "old" gcc stdlib abi.
