### PR TITLE
Increase minimum cmake version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,5 +37,10 @@ jobs:
         run:  conda build -c conda-forge conda-recipe
       - name: windows conda build
         if: matrix.os == 'windows-latest'
+        # HACK: due to a bug in conda-build need to point to
+        # libarchive explicitly.
+        # https://github.com/conda/conda/issues/12563#issuecomment-1494264704
+        env:
+          LIBARCHIVE: C:\Miniconda\Library\bin\archive.dll
         shell: cmd /C CALL {0}
         run: conda build -c conda-forge conda-recipe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
         shell: bash -l {0}
         run:  conda build -c conda-forge conda-recipe
       - name: windows conda build
+        # HACK: due to a bug in conda-build need to point to
+        # libarchive explicitly.
+        # https://github.com/conda/conda/issues/12563#issuecomment-1494264704
+        env:
+          LIBARCHIVE: C:\Miniconda\Library\bin\archive.dll
         if: matrix.os == 'windows-latest'
         shell: cmd /C CALL {0}
         run: conda build -c conda-forge conda-recipe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-w-conda-recipe:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 3.10)
 project(dpct)
 
 # ------------------------------------------

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 message( "\nConfiguring bin:" )
 
 set(Boost_USE_STATIC_LIBS OFF)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 message( "\nConfiguring python wrapper:" )
 
 # dependencies

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 message( "\nConfiguring tests:" )
 find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 


### PR DESCRIPTION
newer versions of cmake cease to support cmake<3.5 - let's see.